### PR TITLE
fix typo word ladder README travis button

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ While the queue is not empty
 Complete the following tasks:
 
 1. Fork this repo and enable github actions
-1. Update the `README.md` file so that the travis button points to your repo
+1. Update the `README.md` file so that the test case badge points to your repo
 1. Implement the `word_ladder`, `verify_word_ladder`, and `_adjacent` functions so that all test cases in `tests/test_main.py` pass
 
 If all test cases pass, you will get full credit.


### PR DESCRIPTION
Calling the test case badge "travis button" may be misleading since this project is using GitHub Actions, not Travis CI.

Submitted in accordance with https://github.com/mikeizbicki/cmc-csci046/blob/027c57a0bbe5c68ec13ccfa5de56a4a969d78b54/extra_credit/README.md?plain=1#L5-L7